### PR TITLE
Fix contentEditable not rendering after reloading page

### DIFF
--- a/app/src/components/blocks/TextBlockComponent.tsx
+++ b/app/src/components/blocks/TextBlockComponent.tsx
@@ -23,8 +23,7 @@ export const TextBlockComponent: React.FC<Props> = ({textBlock}) => {
       element="div"
       placeholder="Enter text"
       data-testid="text-block"
-    >
-      {textBlock.properties.text}
-    </Contenteditable>
+      content={textBlock.properties.text}
+    />
   )
 }

--- a/app/src/components/content/Contenteditable.tsx
+++ b/app/src/components/content/Contenteditable.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 interface Props {
   element: string
+  content?: string
   className?: string
   placeholder?: string
   onChange(text: string): void
@@ -9,8 +10,8 @@ interface Props {
 
 export const Contenteditable: React.FC<Props> = ({
   element,
+  content,
   onChange,
-  children,
   ...props
 }) => {
   const elementRef = React.useRef<HTMLDivElement | null>(null)
@@ -29,14 +30,11 @@ export const Contenteditable: React.FC<Props> = ({
     }
   }, [onChange])
 
-  return React.createElement(
-    element,
-    {
-      contentEditable: true,
-      ref: elementRef,
-      suppressContentEditableWarning: true,
-      ...props,
-    },
-    children,
-  )
+  return React.createElement(element, {
+    contentEditable: true,
+    ref: elementRef,
+    suppressContentEditableWarning: true,
+    ...props,
+    dangerouslySetInnerHTML: {__html: content},
+  })
 }

--- a/app/src/components/pageTitle/PageTitle.tsx
+++ b/app/src/components/pageTitle/PageTitle.tsx
@@ -8,11 +8,10 @@ export const PageTitle: React.FC = () => {
   return (
     <Contenteditable
       element="h1"
+      content={page.properties.title}
       className="container"
       placeholder="Untitled"
       onChange={onUpdateTitle}
-    >
-      {page.properties.title}
-    </Contenteditable>
+    />
   )
 }

--- a/app/src/components/spinner/FullPageSpinner.module.css
+++ b/app/src/components/spinner/FullPageSpinner.module.css
@@ -1,0 +1,7 @@
+.container {
+  min-height: calc(100vh - 60px);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}

--- a/app/src/components/spinner/FullPageSpinner.tsx
+++ b/app/src/components/spinner/FullPageSpinner.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import styles from './FullPageSpinner.module.css'
+
+interface Props {
+  text?: string
+}
+
+export const FullPageSpinner: React.FC<Props> = ({text}) => {
+  return <div className={styles.container}>{text || 'Loading...'}</div>
+}

--- a/app/src/components/spinner/Spinner.tsx
+++ b/app/src/components/spinner/Spinner.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+interface Props {
+  text?: string
+}
+
+export const Spinner: React.FC<Props> = ({text}) => {
+  return <div>{text || 'Loading...'}</div>
+}

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -19,8 +19,9 @@
 }
 
 html,
-body {
-  min-height: 100%;
+body,
+#root {
+  height: 100%;
 }
 
 body {

--- a/app/src/providers/PageProvider.tsx
+++ b/app/src/providers/PageProvider.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
 import {useParams} from 'react-router-dom'
+import {FullPageSpinner} from 'src/components/spinner/FullPageSpinner'
 import {BlockDataStore} from 'src/database/BlockDataStore'
 import {usePageQuery} from 'src/database/queryHooks'
-import {createBlock} from 'src/types/BlockFactory'
 import {PageBlock} from 'src/types/blocks/PageBlock'
-import {BlockType} from 'src/types/BlockType'
 import {useDb} from './DbProvider'
 
 interface PageContextValue {
@@ -41,7 +40,7 @@ export const PageProvider: React.FC = ({children}) => {
     [page, onUpdateTitle],
   )
 
-  if (isLoading) return <div>Loading...</div>
+  if (isLoading) return <FullPageSpinner />
   if (!page) return <h1>Page not found</h1>
 
   return <PageContext.Provider value={value}>{children}</PageContext.Provider>

--- a/app/src/screens/HomeScreen.tsx
+++ b/app/src/screens/HomeScreen.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import {Link} from 'react-router-dom'
 import {AddPageButton} from 'src/components/addBlock/AddPageButton'
+import {FullPageSpinner} from 'src/components/spinner/FullPageSpinner'
 import {usePagesQuery} from 'src/database/queryHooks'
 import {WelcomeScreen} from './WelcomeScreen'
 
@@ -8,7 +9,7 @@ export const HomeScreen: React.FC = () => {
   const {data, error, isLoading} = usePagesQuery()
 
   if (error) throw error
-  if (isLoading) return <div>Loading...</div>
+  if (isLoading) return <FullPageSpinner />
 
   const pages = data!
 


### PR DESCRIPTION
- Fixed html not rendering in contentEditable after reloading page
- Added full-page spinner component